### PR TITLE
Fix 404 logo and adblock+ rule

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,7 +20,7 @@
 <body>
     <header>
         <a href="/" title="NantesJS">
-            <h1 class="logo"></h1>
+            <h1 class="logo"><img class="phone" src="images/logotype.png"></h1>
         </a>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
             </div>
         </div>
 
-        <div class="section social-media">
+        <div class="section networks">
             <div class="container">
                 <h3 class="section-heading">Retrouvez-nous sur les réseaux</h3>
                 <p class="intro">Parce qu'une communauté ne vit que par les discussions et les rencontres régulières de ses membres, participez à l'organisation et à la vie de NantesJS sur les différents groupes de discussion et réseaux</p>

--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
             </div>
         </div>
 
-        <div class="section socials">
+        <div class="section social-media">
             <div class="container">
                 <h3 class="section-heading">Retrouvez-nous sur les réseaux</h3>
                 <p class="intro">Parce qu'une communauté ne vit que par les discussions et les rencontres régulières de ses membres, participez à l'organisation et à la vie de NantesJS sur les différents groupes de discussion et réseaux</p>


### PR DESCRIPTION
Le plugin chrome Adblock Plus bloque l'affichage des div avec la class "socials" (ou social-media). Un changement de nommage résoud le problème.  