### PR TITLE
removing MediaQuery component

### DIFF
--- a/src/components/Header/Menu/Menu.js
+++ b/src/components/Header/Menu/Menu.js
@@ -1,6 +1,5 @@
 import React, { Fragment, createContext, useState } from 'react'
 import { node } from 'prop-types'
-import MediaQuery from 'react-responsive'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import faBars from '@fortawesome/fontawesome-free-solid/faBars'
 

--- a/src/components/Header/Menu/Menu.js
+++ b/src/components/Header/Menu/Menu.js
@@ -21,7 +21,7 @@ export function Menu ({ children }) {
 
   return (
     <Fragment>
-      <MediaQuery maxWidth={991}>
+      <div className={styles.hideOnDesktop}>
         <div className={styles.menu}>
           <button
             className={styles.menu__button}
@@ -42,12 +42,12 @@ export function Menu ({ children }) {
             </div>
           </MenuContext.Provider>
         )}
-      </MediaQuery>
-      <MediaQuery minWidth={992}>
+      </div>
+      <div className={styles.showOnDesktop}>
         <div className={styles.menu__content}>
           {children}
         </div>
-      </MediaQuery>
+      </div>
     </Fragment>
   )
 }

--- a/src/components/Header/Menu/Menu.module.css
+++ b/src/components/Header/Menu/Menu.module.css
@@ -44,3 +44,15 @@
 .menu__content--responsive > * {
   margin-bottom: 10px;
 }
+
+@media screen and (min-width: 992px) {
+  .hideOnDesktop {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 991px) {
+  .showOnDesktop {
+    display: none;
+  }
+}

--- a/src/components/NextMeetup/TitleBar/TitleBar.js
+++ b/src/components/NextMeetup/TitleBar/TitleBar.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { string } from 'prop-types'
-import MediaQuery from 'react-responsive'
 import { withPrefix } from 'gatsby'
 
 import { FullDate } from '../../FullDate'
@@ -18,7 +17,7 @@ TitleBar.propTypes = {
 export function TitleBar ({ title, image, sponsor, venue, date }) {
   return (
     <div className={styles.titlebar}>
-      <MediaQuery maxWidth={767}>
+      <div className={styles.showOnMobile}>
         <div>
           <div
             role="img"
@@ -35,8 +34,8 @@ export function TitleBar ({ title, image, sponsor, venue, date }) {
             Hébergé par <b>{venue}</b>
           </p>
         </div>
-      </MediaQuery>
-      <MediaQuery minWidth={768}>
+      </div>
+      <div className={styles.hideOnMobile}>
         <div
           className={styles.titlebar__imageWrapper}
           style={{ backgroundImage: `url(${ withPrefix(image) })` }}
@@ -48,13 +47,13 @@ export function TitleBar ({ title, image, sponsor, venue, date }) {
             Hébergé par <b>{venue}</b>
           </p>
         </div>
-        <MediaQuery minWidth={992}>
+        <div className={styles.showOnDesktop}>
           <FullDate date={date} />
-        </MediaQuery>
-        <MediaQuery maxWidth={991}>
+        </div>
+        <div className={styles.hideOnTablet}>
           <FullDate date={date} fontSize={.8} />
-        </MediaQuery>
-      </MediaQuery>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/NextMeetup/TitleBar/TitleBar.module.css
+++ b/src/components/NextMeetup/TitleBar/TitleBar.module.css
@@ -28,19 +28,31 @@
   .titlebar h1 {
     font-size: 3.8rem;
   }
+
+  .showOnDesktop {
+    display: none;
+  }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 767px) {  
   .titlebar {
     flex-direction: column;
     height: auto;
   }
 
-  .titlebar > div:first-child {
+  .showOnMobile {
+    width: 100%;
+  }
+
+  .showOnMobile > div:first-child {
     display: flex;
     align-items: center;
     justify-content: space-between;
     width: 100%;
+  }
+
+  .hideOnMobile {
+    display: none;
   }
 
   .titlebar__infos {
@@ -56,6 +68,11 @@
   .titlebar__image-wrapper {
     height: 9rem;
     width: 9rem;
+  }
+
+  .date__day {
+    font-size: 4.64rem;
+    line-height: 3.84rem;
   }
 }
 
@@ -100,4 +117,37 @@
 .date__year {
   writing-mode: vertical-rl;
   text-orientation: upright;
+}
+
+@media (min-width: 992px) {
+  .hideOnTablet {
+    display: none;
+  }
+
+  .showOnTablet {
+    display: block;
+  }
+}
+
+@media (min-width: 768px) {
+  .hideOnMobile {
+    width: 100%;
+    /* same as titlebar */
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    min-height: 15rem;
+  }
+
+  .hideOnTablet {
+    margin-left: auto;
+  }
+
+  .showOnDesktop {
+    margin-left: auto;
+  }
+
+  .showOnMobile {
+    display: none;
+  }
 }

--- a/src/components/OldMeetups/OldMeetups.js
+++ b/src/components/OldMeetups/OldMeetups.js
@@ -1,7 +1,6 @@
 import React, { Fragment } from 'react'
 import { array } from 'prop-types'
 import classNames from 'classnames'
-import MediaQuery from 'react-responsive'
 import { withPrefix } from 'gatsby'
 import he from 'he'
 

--- a/src/components/OldMeetups/OldMeetups.js
+++ b/src/components/OldMeetups/OldMeetups.js
@@ -118,11 +118,11 @@ export function OldMeetups ({ meetups }) {
                     </div>
                   </div>
                   <Talks talks={meetup.talks}/>
-                  <MediaQuery maxWidth={767}>
+                  <div className={styles.showOnMobile}>
                     <div className={styles.meetup__date}>
                       <p>{meetup.date}</p>
                     </div>
-                  </MediaQuery>
+                  </div>
                 </div>
               </div>
             </Fragment>

--- a/src/components/OldMeetups/OldMeetups.module.css
+++ b/src/components/OldMeetups/OldMeetups.module.css
@@ -161,3 +161,13 @@
       display: none;
   }
 }
+
+@media screen and (max-width: 767px) {
+  .hideOnMobile {
+      display: block;
+  }
+
+  .showOnMobile {
+      display: none;
+  }
+}

--- a/src/components/OldMeetups/OldMeetups.module.css
+++ b/src/components/OldMeetups/OldMeetups.module.css
@@ -162,7 +162,7 @@
   }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (min-width: 768px) {
   .hideOnMobile {
       display: block;
   }


### PR DESCRIPTION
Closes #129.

I used the same naming used in `<OldMeetups />`, e.g. `.showOnMobile` and `.hideOnMobile`.

I also added the class `.date__day` in `Titlebar` css to screens below 768px.