### PR TITLE
Remove null in rss feed when no address in meetup

### DIFF
--- a/rss.js
+++ b/rss.js
@@ -22,7 +22,7 @@ const formatContent = ({
       <p>${t.description}</p>
       <p>Par:</p>
       <ul>
-        ${t.speakers.reduce((b, s) => isUrl(s.link) ? (`${b}<li><a href="${s.link}">${s.name}</a></li>`) : 
+        ${t.speakers.reduce((b, s) => isUrl(s.link) ? (`${b}<li><a href="${s.link}">${s.name}</a></li>`) :
         `${b}<li><a href="${"https://twitter.com/"+s.link}">${s.name}</a></li>`, '')}
       </ul>
     `, '');
@@ -37,7 +37,7 @@ const formatContent = ({
     } = venue;
     const location = `
   ${link ? `<a href="${link}">${name}</a>`: name}<br/>
-  ${address} ${postal_code} ${city}
+  ${address ? `${address}` : ""} ${postal_code ? `${postal_code}` : ""} ${city ? `${city}` : ""}
   `;
 
   return `


### PR DESCRIPTION
When the covid strike too hard, we have to do our meeting remotely. In this case, in the rss feed, the address is displayed as `null null null`.